### PR TITLE
Small changes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# xcode noise
+build/
+*.pyc
+*~.nib/
+*.pbxuser
+*.perspective
+*.perspectivev3
+*.xcuserstate
+*.xccheckout
+project.xcworkspace/
+xcuserdata/

--- a/AudioSynthesis/SoundGenerator.swift
+++ b/AudioSynthesis/SoundGenerator.swift
@@ -8,23 +8,23 @@
 
 class SoundGenerator : NSObject
 {
-    var oscillators = [FMSynth]()
+    var oscillators = [Synth]()
     
     final func setUp()
     {
         for i in 0 ..< Constants.numInstruments
         {
-            let fmOscillator = FMSynth()
-            AKOrchestra.addInstrument(fmOscillator)
+            let synth = Synth()
+            AKOrchestra.addInstrument(synth)
             
-            oscillators.append(fmOscillator)
+            oscillators.append(synth)
         }
 
         AKOrchestra.start()
 
-        for fmOscillator in oscillators
+        for oscillator in oscillators
         {
-            fmOscillator.play()
+            oscillator.play()
         }
     }
     
@@ -40,11 +40,11 @@ class SoundGenerator : NSObject
 }
 
 
-class FMSynth: AKInstrument
+class Synth: AKInstrument
 {
  
     var frequency = AKInstrumentProperty(value: 0,  minimum: 0, maximum: Constants.frequencyScale)
-    var amplitude = AKInstrumentProperty(value: 0, minimum: 0,   maximum: 0.25)
+    var amplitude = AKInstrumentProperty(value: 0,  minimum: 0, maximum: 0.25)
     
     override init()
     {
@@ -53,12 +53,13 @@ class FMSynth: AKInstrument
         addProperty(frequency)
         addProperty(amplitude)
         
-        let fmOscillator = AKFMOscillator()
+        let oscillator = AKOscillator()
         
-        fmOscillator.baseFrequency = frequency
-        fmOscillator.amplitude = amplitude
+        oscillator.frequency = frequency
+        oscillator.amplitude = amplitude
         
-        connect(fmOscillator)
-        connect(AKAudioOutput(audioSource: fmOscillator))
+        connect(oscillator)
+        connect(AKAudioOutput(audioSource: oscillator))
     }
 }
+

--- a/AudioSynthesis/ToneWidget.swift
+++ b/AudioSynthesis/ToneWidget.swift
@@ -30,7 +30,7 @@ class ToneWidget: UIControl
         amplitudeDial.addTarget(self, action: "dialChangeHander", forControlEvents: UIControlEvents.ValueChanged)
         
         frequencyDial.currentValue = 0.25 * Float(channelNumber % 4 + 1)
-        amplitudeDial.currentValue = 0.25 * Float(4 - channelNumber % 4)
+        amplitudeDial.currentValue = 0.25 //* Float(4 - channelNumber % 4)
         
         dialChangeHander()
     }


### PR DESCRIPTION
In order to have the waveforms shown really represent the sound, I think it would be better to use the AKOscillator which uses a pure sine wave by default.  The AKFMOscillator has defaults for modulation so there were overtones not represented in your waveforms.  The only other change was to let the amplitudes start off at 0.25, which gave a more pleasing initial sound to my ears, but you can take that or leave it. The code is still there just commented out.
